### PR TITLE
修改了两个小bug

### DIFF
--- a/auto_player.py
+++ b/auto_player.py
@@ -23,7 +23,7 @@ class Player(object):
             re = os.popen(f'{adb} devices').read()
             print(re)
             device_list = [e.split('\t')[0] for e in re.split('\n') if '\tdevice' in e]
-            assert len(device_list) >= 1, '未检测到ADB连接设备'
+            assert len(device_list) <= 1, '未检测到ADB连接设备'
             self.device = device_list[adb_num] 
             re = os.popen(f'{adb} -s {self.device} shell wm size').read()
             print(re)
@@ -91,8 +91,8 @@ class Player(object):
 
     #拖动或长按
     def drag(self, position_start, end, second=0.2):
-        sx, sy = random_offset(position_start)
-        ex, ey = random_offset(end)
+        sx, sy = self.random_offset(position_start)
+        ex, ey = self.random_offset(end)
         if self.adb_mode:
             cmd = f'{adb} -s {self.device} shell input touchscreen swipe {sx} {sy} {ex} {ey}'
             os.system(cmd)


### PR DESCRIPTION
1.adb连接
判断时应该是<=，否则列表长度越界直接报错（本人找了好久bug一度以为是自己电脑adb的问题）
ps 当只有一个模拟器的时候，adb_num直接填0即可，无需填写端口（一般为五位）
2.drag函数中random_offset忘记加self辣！
3.vscode打开时有概率出现“缩进中制表符和空格的使用不一致”的问题，设置内editor调一下即可（百度）